### PR TITLE
Fix window controls on secondary monitors with different positions/sizes

### DIFF
--- a/src/main/java/ch/micheljung/fxwindow/DecorationWindowProcedure.java
+++ b/src/main/java/ch/micheljung/fxwindow/DecorationWindowProcedure.java
@@ -200,14 +200,10 @@ class DecorationWindowProcedure implements WinUser.WindowProc {
 
           if (isMaximized(hwnd)) {
             nCalcSizeParams.rgrc[0].top += resizeBorderThickness;
-            nCalcSizeParams.rgrc[0].left += resizeBorderThickness;
-            nCalcSizeParams.rgrc[0].right -= resizeBorderThickness;
-            nCalcSizeParams.rgrc[0].bottom -= resizeBorderThickness;
-          } else {
-            nCalcSizeParams.rgrc[0].left += resizeBorderThickness;
-            nCalcSizeParams.rgrc[0].right -= resizeBorderThickness;
-            nCalcSizeParams.rgrc[0].bottom -= resizeBorderThickness;
           }
+          nCalcSizeParams.rgrc[0].left += resizeBorderThickness;
+          nCalcSizeParams.rgrc[0].right -= resizeBorderThickness;
+          nCalcSizeParams.rgrc[0].bottom -= resizeBorderThickness;
 
           nCalcSizeParams.write();
           return WVR_VALIDRECTS;

--- a/src/main/java/ch/micheljung/fxwindow/Rect.java
+++ b/src/main/java/ch/micheljung/fxwindow/Rect.java
@@ -19,6 +19,6 @@ public class Rect {
     left = (int) stage.getX();
     right = (int) (stage.getX() + stage.getWidth());
     top = (int) stage.getY();
-    bottom = (int) (stage.getX() + stage.getHeight());
+    bottom = (int) (stage.getY() + stage.getHeight());
   }
 }

--- a/src/main/java/ch/micheljung/fxwindow/User32Ex.java
+++ b/src/main/java/ch/micheljung/fxwindow/User32Ex.java
@@ -32,6 +32,24 @@ public interface User32Ex extends User32 {
   /** Call a window procedure. */
   LRESULT CallWindowProc(LONG_PTR proc, HWND hWnd, int uMsg, WPARAM uParam, LPARAM lParam);
 
+  /**
+   * Determines whether a window is maximized.
+   * @see <a href="https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-iszoomed">IsZoomed documentation</a>
+   */
+  boolean IsZoomed(HWND hWnd);
+
+  /**
+   * Determines the DPI for a window.
+   * @see <a href="https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdpiforwindow">GetDpiForWindow documentation</a>
+   */
+  int GetDpiForWindow(HWND hwnd);
+
+  /**
+   * Converts the client-area coordinates of a specified point to screen coordinates.
+   * @see <a href="https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-clienttoscreen">ClientToScreen documentation</a>
+   */
+  boolean ClientToScreen(HWND hwnd, POINT clientTopLeft);
+
   @Structure.FieldOrder({"attribute", "data", "sizeOfData"})
   class WindowCompositionAttributeData extends Structure implements Structure.ByReference {
     public int attribute;


### PR DESCRIPTION
### Problem: 
When a JavaFX window is maximized on a secondary monitor, the caption area and window control buttons become non-interactive. (For me my second monitor is both different in size and positioned relatively to my primary monitor.)

### Fixes:
Used Win32 IsZoomed() API for maximization detection.
Add DPI-aware top inset calculation using GetClientRect(), ClientToScreen(), and GetDpiForWindow().
Changed Rect to use getY() for the bottom instead of getX().

### License question (separate from this fix)
I also wanted to ask if you would consider changing the license to be compatible with LGPL 2.1+ (for example LGPL or GPL with a classpath exception).
The reason I'm asking this is, because my project uses LGPL 2.1+ and bundles all runtime dependencies in a single jar for distribution but the FxStage maven license is GNU 3.0. Which does not allow binary distribution, without copyleft.